### PR TITLE
Fix/frontend/update btn

### DIFF
--- a/frontend/src/components/UpdateBtn/UpdateBtn.css
+++ b/frontend/src/components/UpdateBtn/UpdateBtn.css
@@ -26,5 +26,11 @@
 
 /* 更新済 (Slide 8): 「閉じる」ボタンの状態 */
 .update-main-button.updated {
+  pointer-events: auto;
+}
+
+.update-main-button.updated:hover {
+  transform: none;
   background-color: #ffffff;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
Issue[#57](https://github.com/kc3hack/2026_team7/issues/57)の解決
  【問題点】
   status が 'updated' のときも
   .update-main-button:hover が適用されてしまう。

   そのため見た目が意図とずれる

   updated のときは hover の動きをさせたくない。

   【解決方法】
   updated 状態専用の hover を定義し、
   transform や box-shadow を無効化する。