### PR TITLE
.stats-gridのカラム設定を修正し、レスポンシブデザインを適用

### DIFF
--- a/frontend/src/components/Section/Section4/Section4.css
+++ b/frontend/src/components/Section/Section4/Section4.css
@@ -4,7 +4,7 @@ body {
 
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 40px 80px;
   padding: 20px;
 }


### PR DESCRIPTION
issue [#63](https://github.com/kc3hack/2026_team7/issues/63) 
Section4のレスポンシブ対応を実装

- stats-gridをCSS Gridで構築
- PC表示は2列レイアウトを維持
- 画面幅768px以下で1列表示に変更
