### PR TITLE
Section3コンポーネントの内容をpropsを使用して動的に表示するように変更

### DIFF
--- a/frontend/src/components/Section/Section3/Section3.tsx
+++ b/frontend/src/components/Section/Section3/Section3.tsx
@@ -11,11 +11,18 @@ const Section3 = (props: Section3Props) => {
   return (
     <BoxFrame>
       <div className="pad_box">
-        <TitleContent title="sample" content="サンプル文章あああああああああああ" />
-        <TitleContent title="sample2" content="サンプル文章あああああああああああ" />
-        <TitleContent title="" content='サンプル文章あああ'></TitleContent>
-        <TitleContent title="" content='サンプル文章あああ'></TitleContent>
-        <TitleContent title="" content='サンプル文章あああ'></TitleContent>
+        <TitleContent title="Website" content={props.website ?? "なし"}/>
+        {props.social_accounts?.length ? (
+          props.social_accounts.map((account, index) => (
+            <TitleContent
+              key={index}
+              title={index === 0 ? "SNS" : ""}
+              content={account}
+            />
+          ))
+        ) : (
+          <TitleContent title="SNS" content="なし" />
+        )}
       </div>
     </BoxFrame>
   );


### PR DESCRIPTION
issue [#80](https://github.com/kc3hack/2026_team7/issues/80)

## 概要
Section3にSNS表示機能を追加しました。

## 変更内容
- social_accounts をmapで表示するように実装
- indexが0のときのみタイトル「SNS」を表示
- social_accountsが空またはundefinedの場合は「なし」を表示
- Websiteがundefinedの場合も「なし」を表示するよう統一

## 影響範囲
- Section3コンポーネントのみ