### PR TITLE
Section4コンポーネントでプロパティを使用して値を動的に表示するように修正しました

### DIFF
--- a/frontend/src/components/Section/Section4/Section4.tsx
+++ b/frontend/src/components/Section/Section4/Section4.tsx
@@ -13,10 +13,10 @@ const Section4 = (props: Section4Props) => {
   return (
     <BoxFrame>
       <div className="stats-grid">
-        <LabelValue label="Repositories" value="68" />
-        <LabelValue label="Repositories" value="68" />
-        <LabelValue label="Repositories" value="68" />
-        <LabelValue label="Repositories" value="68" />
+        <LabelValue label="Repositories" value={props.repositories} />
+        <LabelValue label="Total Bytes" value={props.total_bytes} />
+        <LabelValue label="Activity Grade" value={props.activity_grade} />
+        <LabelValue label="Charisma Grade" value={props.charisma_grade} />
       </div>
     </BoxFrame>
   );


### PR DESCRIPTION
issue [#85](https://github.com/kc3hack/2026_team7/issues/85)
## 概要
Section4内でハードコードされていた値を削除し、
受け取ったpropsを表示するように修正しました。

## 変更内容
- value="68" の固定値を削除
- repositories / total_bytes / activity_grade / charisma_grade を
  propsから参照するように変更

## 影響範囲
- Section4コンポーネントのみ

## 目的
動的データを正しく表示できるようにするため。
